### PR TITLE
Fixes crash bug

### DIFF
--- a/Sources/TweePlaceholderTextField.swift
+++ b/Sources/TweePlaceholderTextField.swift
@@ -286,12 +286,14 @@ open class TweePlaceholderTextField: UITextField {
 	}
 
 	private func enablePlaceholderHeightConstraint() {
+//        guard placeholderLayoutGuide.owningView != nil else { return }
 		placeholderGuideHeightConstraint?.isActive = false
 		placeholderGuideHeightConstraint = placeholderLayoutGuide.heightAnchor.constraint(equalTo: heightAnchor)
 		placeholderGuideHeightConstraint?.isActive = true
 	}
 
 	private func disablePlaceholderHeightConstraint() {
+        guard placeholderLayoutGuide.owningView != nil else { return }
 		placeholderGuideHeightConstraint?.isActive = false
 		placeholderGuideHeightConstraint = placeholderLayoutGuide.heightAnchor.constraint(equalToConstant: 0)
 		placeholderGuideHeightConstraint?.isActive = true


### PR DESCRIPTION
### Implementation Details :construction:
Fixes crash bug #21  produced by commit b49c32b 
while adding/removing constraint for placeholder label
it crashes on runtime saying the views are not in same view hierarchy
tested on Xcode 10 GM seed